### PR TITLE
Fixing codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,5 @@ section of the main RAIL Read The Docs page.
 
 ## TODO List
 
-- Configure Codecov for the repository (https://github.com/apps/codecov)
 - Create an example notebook
 - Citing?

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![alt text](https://raw.githubusercontent.com/jlvdb/yet_another_wizz/main/docs/source/_static/logo-dark.png)
 
 [![Template](https://img.shields.io/badge/Template-LINCC%20Frameworks%20Python%20Project%20Template-brightgreen)](https://lincc-ppt.readthedocs.io/en/latest/)
-[![codecov](https://codecov.io/gh/LSSTDESC/pz-rail-yaw/branch/main/graph/badge.svg)](https://codecov.io/gh/LSSTDESC/pz-rail-yaw)
+[![codecov](https://codecov.io/gh/LSSTDESC/rail_yaw/graph/badge.svg?token=BsmWz2v0qL)](https://codecov.io/gh/LSSTDESC/rail_yaw)
 [![PyPI](https://img.shields.io/pypi/v/yaw_rail?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/yaw_rail/)
 
 # pz-rail-yaw


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
The python package name differs from the actual repository name, so the generated codecov badge is invalid

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
