### PR TITLE
udpated test data URL

### DIFF
--- a/examples/full_example.ipynb
+++ b/examples/full_example.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
     "from yaw import UniformRandoms\n",
     "\n",
     "from rail.yaw_rail import (\n",
@@ -34,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mock_data = get_dc2_test_data()  # data gets downloaded on-the-fly\n",
+    "mock_data = get_dc2_test_data()\n",
     "redshifts = mock_data[\"z\"].to_numpy()\n",
     "zmin = redshifts.min()\n",
     "zmax = redshifts.max()\n",
@@ -47,13 +46,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "seed = 12345\n",
     "angular_rng = UniformRandoms(\n",
     "    mock_data[\"ra\"].min(),\n",
     "    mock_data[\"ra\"].max(),\n",
     "    mock_data[\"dec\"].min(),\n",
     "    mock_data[\"dec\"].max(),\n",
-    "    seed=seed,\n",
+    "    seed=12345,\n",
     ")\n",
     "mock_rand = angular_rng.generate(n_data * 10, draw_from=dict(z=redshifts))"
    ]

--- a/examples/full_example.ipynb
+++ b/examples/full_example.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mock_data = get_dc2_test_data()\n",
+    "mock_data = get_dc2_test_data()  # downloads test data, cached for future calls\n",
     "redshifts = mock_data[\"z\"].to_numpy()\n",
     "zmin = redshifts.min()\n",
     "zmax = redshifts.max()\n",

--- a/src/rail/yaw_rail/cache.py
+++ b/src/rail/yaw_rail/cache.py
@@ -23,7 +23,7 @@ from rail.core.data import DataHandle, TableHandle
 from rail.yaw_rail.logging import yaw_logged
 from rail.yaw_rail.stage import YawRailStage
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from pandas import DataFrame
     from yaw.catalogs.scipy import ScipyCatalog
     from yaw.core.coordinates import Coordinate, CoordSky

--- a/src/rail/yaw_rail/correlation.py
+++ b/src/rail/yaw_rail/correlation.py
@@ -20,7 +20,7 @@ from rail.yaw_rail.cache import YawCacheHandle
 from rail.yaw_rail.logging import yaw_logged
 from rail.yaw_rail.stage import YawRailStage, create_param
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from rail.yaw_rail.cache import YawCache
 
 __all__ = [
@@ -74,11 +74,11 @@ class YawBaseCorrelate(YawRailStage):
 
     @abstractmethod
     def correlate(self, *inputs: YawCache) -> YawCorrFuncHandle:
-        pass
+        pass  # pragma: no cover
 
     @abstractmethod
     def run(self) -> None:
-        pass
+        pass  # pragma: no cover
 
 
 class YawAutoCorrelate(

--- a/src/rail/yaw_rail/stage.py
+++ b/src/rail/yaw_rail/stage.py
@@ -19,7 +19,7 @@ from ceci.config import StageParameter
 from rail.core.stage import RailStage
 from rail.yaw_rail.logging import config_verbose
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from rail.core.data import DataHandle
 
 __all__ = [

--- a/src/rail/yaw_rail/utils.py
+++ b/src/rail/yaw_rail/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from pandas import read_parquet
@@ -12,6 +13,7 @@ __all__ = [
 ]
 
 
+@lru_cache
 def get_dc2_test_data() -> DataFrame:
     link = "https://portal.nersc.gov/cfs/lsst/PZ/test_dc2_rail_yaw.pqt"
     return read_parquet(link)

--- a/src/rail/yaw_rail/utils.py
+++ b/src/rail/yaw_rail/utils.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import os
-import subprocess
-from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING
 
 from pandas import read_parquet
@@ -16,21 +13,5 @@ __all__ = [
 
 
 def get_dc2_test_data() -> DataFrame:
-    link = (
-        "https://drive.usercontent.google.com/"
-        "download?id=1n9_vfbTlUrlyR6eUwHxJLZ35OjYf8Uyf&export=download"
-    )
-    with TemporaryDirectory() as tmp_path:
-        path = os.path.join(tmp_path, "test_dc2_rail_yaw.pqt")
-        try:
-            subprocess.run(
-                ["curl", link, "-o", path],
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                timeout=10,
-            )
-            data = read_parquet(path)
-        except Exception as err:  # pragma: no cover
-            raise OSError("downloading test data failed") from err
-    return data
+    link = "https://portal.nersc.gov/cfs/lsst/PZ/test_dc2_rail_yaw.pqt"
+    return read_parquet(link)

--- a/src/rail/yaw_rail/utils.py
+++ b/src/rail/yaw_rail/utils.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from pandas import read_parquet
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from pandas import DataFrame
 
 __all__ = [
@@ -31,6 +31,6 @@ def get_dc2_test_data() -> DataFrame:
                 timeout=10,
             )
             data = read_parquet(path)
-        except Exception as err:
+        except Exception as err:  # pragma: no cover
             raise OSError("downloading test data failed") from err
     return data

--- a/tests/yaw_rail/conftest.py
+++ b/tests/yaw_rail/conftest.py
@@ -8,7 +8,7 @@ from yaw import UniformRandoms
 from rail.core.stage import RailStage
 from rail.yaw_rail.utils import get_dc2_test_data
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from pandas import DataFrame
     from rail.core.data import DataStore
 


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

Updated the URL for the test data file, added some no-cover pragmas to code sections that are related to abstract classes or typing annotations.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
