### PR TITLE
Added missing docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,3 @@ code used.  A list of such codes is included in the
 [Citing RAIL](https://lsstdescrail.readthedocs.io/en/stable/source/citing.html)
 section of the main RAIL Read The Docs page.
 
-## TODO List
-
-- Create an example notebook
-- Citing?

--- a/examples/full_example.ipynb
+++ b/examples/full_example.ipynb
@@ -27,32 +27,8 @@
     "including a summary of all currently implemented optional parameters (commented).\n",
     "It is not meant to be a demonstaration of the performance of *yet_another_wizz*\n",
     "since the example data used here is very small and the resulting signal-to-noise\n",
-    "ratio is quite poor."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Ensure that no cached data is present if a previous run has been interrupted.\n",
-    "# TODO: properly implement option to overwrite an exsisting cache directory.\n",
-    "def clean_up():\n",
-    "    from shutil import rmtree\n",
-    "    for key in (\"ref\", \"unk\"):\n",
-    "        try:\n",
-    "            rmtree(f\"test_{key}\")\n",
-    "        except FileNotFoundError:\n",
-    "            pass\n",
+    "ratio is quite poor.\n",
     "\n",
-    "clean_up()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "We first import the required stages from the *yet_another_wizz* wrapper. Each of\n",
     "the stages maps to one of the steps listed in the beginning."
    ]
@@ -74,7 +50,12 @@
     "    YawSummarize,       # step 5\n",
     "    YawCacheDrop,       # step 6\n",
     ")  # equivalent: from rail.yaw_rail import *\n",
-    "from rail.yaw_rail.cache import stage_helper  # utility for YawCacheCreate"
+    "from rail.yaw_rail.cache import stage_helper  # utility for YawCacheCreate\n",
+    "\n",
+    "# configure RAIL datastore to allow overwriting data\n",
+    "from rail.core.stage import RailStage\n",
+    "DS = RailStage.data_store\n",
+    "DS.__class__.allow_overwrite = True"
    ]
   },
   {
@@ -235,6 +216,7 @@
     "    name=\"ref\",\n",
     "    aliases=stage_helper(\"ref\"),\n",
     "    path=\"./test_ref\",\n",
+    "    overwrite=True,  # default: False\n",
     "    ra_name=\"ra\",\n",
     "    dec_name=\"dec\",\n",
     "    redshift_name=\"z\",\n",
@@ -289,6 +271,7 @@
     "    name=\"unk\",\n",
     "    aliases=stage_helper(\"unk\"),\n",
     "    path=\"./test_unk\",\n",
+    "    overwrite=True,  # default: False\n",
     "    ra_name=\"ra\",\n",
     "    dec_name=\"dec\",\n",
     "    # redshift_name=,\n",
@@ -389,7 +372,7 @@
    "outputs": [],
    "source": [
     "counts_ss = w_ss.data  # extract payload from handle\n",
-    "counts_ss.dd  # 5 patches by 5 patches, in 8 redshift bins"
+    "counts_ss.dd"
    ]
   },
   {

--- a/src/rail/yaw_rail/__init__.py
+++ b/src/rail/yaw_rail/__init__.py
@@ -24,6 +24,7 @@ clutering redshift estimate from yet_another_wizz.
 from .cache import YawCacheCreate, YawCacheDrop
 from .correlation import YawAutoCorrelate, YawCrossCorrelate
 from .summarize import YawSummarize
+from .utils import get_dc2_test_data
 
 __all__ = [
     "YawAutoCorrelate",

--- a/src/rail/yaw_rail/cache.py
+++ b/src/rail/yaw_rail/cache.py
@@ -11,7 +11,6 @@ between RAIL stages to define inputs for the correlation function stages.
 
 from __future__ import annotations
 
-import json
 import os
 import shutil
 from typing import TYPE_CHECKING, Any, TextIO
@@ -90,18 +89,39 @@ config_cache = dict(
 
 
 def normalise_path(path: str) -> str:
-    """
-    Substitute UNIX style home directories and environment variables in path
-    names.
-    """
+    """Substitute UNIX style home directories and environment variables in path
+    names."""
     return os.path.expandvars(os.path.expanduser(path))
 
 
-def get_patch_method(patch_centers, patch_name, n_patches) -> Any:
+def get_patch_method(
+    patch_centers: ScipyCatalog | Coordinate | None,
+    patch_name: str | None,
+    n_patches: int | None,
+) -> ScipyCatalog | Coordinate | str | int:
     """
-    Select the preferred parameter value from the set of optional patch
-    construction parameters. Raises a `ValueError` if none of the parameters is
-    configured.
+    Extract the preferred parameter value from the patch parameters, follow a
+    hierarchy of preference.
+
+    Parameters
+    ----------
+    patch_centers : ScipyCatalog, Coordinate or None
+        A *yet_another_wizz* catalog or coordinates, or `None` if not set.
+    patch_name : str or None
+        The name of the column that list the patch indices or `None` if not set.
+    n_patches: int or None
+        The number of patches to generate using k-means clustering or `None` if
+        not set.
+
+    Returns
+    -------
+    ScipyCatalog, Coordinate, str, or int
+        The preferred parameter value to configure the patch creation.
+
+    Raises
+    ------
+    ValueError
+        If all parameter values are set to `None`.
     """
     # preferred order, "create" should be the last resort
     if patch_centers is not None:  # deterministic and consistent
@@ -115,11 +135,19 @@ def get_patch_method(patch_centers, patch_name, n_patches) -> Any:
 
 class YawCatalog:
     """
-    Wrapper around a *yet_another_wizz* catalog.
+    Wrapper around a *yet_another_wizz* catalog that is cached on disk in
+    spatial patches.
+
+    Parameters
+    ----------
+    path : str
+        Path to the directory in which the data is cached.
     """
 
     path: str
+    """Path to the directory in which the data is cached."""
     catalog: ScipyCatalog | None
+    """Catalog instance or `None` if no data is cached yet."""
 
     def __init__(self, path: str) -> None:
         self.path = normalise_path(path)
@@ -127,12 +155,44 @@ class YawCatalog:
         self._patch_center_callback = None
 
     def set_patch_center_callback(self, cat: YawCatalog) -> None:
+        """
+        Register a different `YawCatalog` instance that defines the patch
+        centers to use.
+
+        If set, all patch configuration parameters in `set` are ignored and the
+        patch centers of the linked catalog are used instead. Useful to ensure
+        that two catalogs have consistent patch centers without explicitly
+        setting them a priori.
+
+        Parameters
+        ----------
+        cat : YawCatalog
+            The catalog instance that acts are reference for the patch centers.
+        """
+        if not isinstance(cat, YawCatalog):
+            raise TypeError("referenced catalog is not a 'YawCatalog'")
         self._patch_center_callback = lambda: cat.get().centers
 
     def exists(self) -> bool:
+        """Whether the catalog's cache directory exists."""
         return os.path.exists(self.path)
 
     def get(self) -> ScipyCatalog:
+        """
+        Access the catalog instance without loading all data to memory.
+
+        Retrieves the catalog metadata from disk if not in memory.
+
+        Returns
+        -------
+        ScipyCatalog
+            The cached catalog instance.
+
+        Raises
+        ------
+        FileNotFoundError
+            If not data is cached at the specifed path.
+        """
         if not self.exists():
             raise FileNotFoundError(f"no catalog cached at {self.path}")
         if self.catalog is None:
@@ -145,14 +205,49 @@ class YawCatalog:
         ra_name: str,
         dec_name: str,
         *,
-        patch_name: str | None = None,
         patch_centers: ScipyCatalog | Coordinate | None = None,
+        patch_name: str | None = None,
         n_patches: int | None = None,
         redshift_name: str | None = None,
         weight_name: str | None = None,
         overwrite: bool = False,
         **kwargs,  # pylint: disable=W0613; allows dict-unpacking of whole config
     ) -> ScipyCatalog:
+        """
+        Split a new data set in spatial patches and cache it.
+
+        Parameters
+        ----------
+        source : DataFrame or str
+            Data source, either a `DataFrame` or a FITS, Parquet, or HDF5 file.
+        ra_name : str
+            Column name of right ascension data in degrees.
+        dec_name : str
+            Column name of declination data in degrees.
+        patch_centers : ScipyCatalog, Coordinate or None
+            A *yet_another_wizz* catalog or coordinates, or `None` if not set.
+        patch_name : str or None
+            The name of the column that list the patch indices or `None` if not set.
+        n_patches: int or None
+            The number of patches to generate using k-means clustering or `None` if
+            not set.
+        redshift_name : str or None, optional
+            Column name of redshifts.
+        weight_name: str or None, optional
+            Column name of per-object weigths.
+        overwrite: bool, optional
+            Whether to overwrite an existing, cached data set.
+
+        Returns
+        -------
+        ScipyCatalog
+            The cached catalog instance.
+
+        Raises
+        ------
+        FileExistsError
+            If there is already a data set cached and `overwrite` is not set.
+        """
         if self.exists():
             if overwrite:
                 shutil.rmtree(self.path)
@@ -160,12 +255,14 @@ class YawCatalog:
                 raise FileExistsError(self.path)
         os.makedirs(self.path)
 
+        # check if any reference catalog is registered that overwrites the
+        # provided patch centers
         try:
             patch_centers = self._patch_center_callback()
         except (TypeError, FileNotFoundError):
             pass
 
-        if isinstance(source, str):
+        if isinstance(source, str):  # dealing with a file
             patches = get_patch_method(
                 patch_centers=patch_centers,
                 patch_name=patch_name,
@@ -182,6 +279,7 @@ class YawCatalog:
             )
 
         else:
+            # ensure that patch_centers are always used if provided
             if patch_centers is not None:
                 patch_name = None
                 n_patches = None
@@ -198,6 +296,7 @@ class YawCatalog:
             )
 
     def drop(self) -> None:
+        """Delete the cached data from disk and unset the catalog instance."""
         if self.exists():
             shutil.rmtree(self.path)
         self.catalog = None
@@ -205,22 +304,35 @@ class YawCatalog:
 
 class YawCache:
     """
-    A cache directory for yet_another_wizz to store a data and (optional)
-    random catalogue that is split into spatial patches.
+    A cache directory for *yet_another_wizz* to store a data and (optional)
+    random catalogue.
 
-    Create a new instance with the `create()` method or open an existing cache
-    (no checks are performed). Remove the cache using the `drop()` method.
-    Additional methods exist to populte the cache or retrieve the cached data
-    in the yet_another_wizz catalog format.
+    The data sets are split into consistent spatial patches used for spatial
+    resampling and covariance estiation by *yet_another_wizz* and wrapped by
+    `YawCatalog` instances. Once any data set is specifed, the other data set
+    will inherit its patch centers.
+
+    Create a new instance with the `create` method or open an existing cache.
+    If an existing cache is used, the code checks if the provided directory is a
+    valid cache. To interact with the data set and the randoms, directly access
+    the methods of the `data` and `rand` attributes.
+
+    Parameters
+    ----------
+    path : str
+        Path at which the data and random catalogues are cached, must exist and
+        has to be created with the `create` method.
     """
 
     _flag_path = ".yaw_cache"  # file to a cache directory, safeguard for .drop()
     path: str
+    """Path at which the data and random catalogues are cached."""
     data: YawCatalog
+    """Catalog instance for the data set."""
     rand: YawCatalog
+    """Catalog instance for the randoms."""
 
     def __init__(self, path: str) -> None:
-        """Open an existing cache directory at the specified path."""
         self.path = normalise_path(path)
 
         if not os.path.exists(self.path):
@@ -235,12 +347,27 @@ class YawCache:
 
     @classmethod
     def is_valid(cls, path: str) -> bool:
+        """Whether the provided path is a valid cache."""
         indicator_path = os.path.join(path, cls._flag_path)
         return os.path.exists(indicator_path)
 
     @classmethod
     def create(cls, path: str, overwrite: bool = False) -> YawCache:
-        """Create an empty cache directory at the specifed path."""
+        """
+        Create an empty cache directory at the specifed path.
+
+        Parameters
+        ----------
+        path : str
+            Path at which the data and random catalogues are cached.
+        overwrite : bool, optional
+            Whether to overwrite an existing cache directory.
+
+        Returns
+        -------
+        YawCache
+            The newly created cache instance.
+        """
         normalised = normalise_path(path)
 
         if os.path.exists(normalised):
@@ -261,7 +388,20 @@ class YawCache:
         return f"{self.__class__.__name__}(path='{self.path}')"
 
     def get_patch_centers(self) -> CoordSky:
-        """Get the patch centers for a non-empty cache."""
+        """
+        Get the patch center coordinates.
+
+        Returns
+        -------
+        CoordSky
+            The patch center coordinates in degrees as
+            `yaw.core.coordinates.CoordSky` instance.
+
+        Raises
+        ------
+        FileNotFoundError
+            If not data is cached yet.
+        """
         if self.rand.exists():
             return self.rand.get().centers
         if self.data.exists():
@@ -269,15 +409,42 @@ class YawCache:
         raise FileNotFoundError("cache is empty")
 
     def n_patches(self) -> int:
-        """Get the number of spatial patches for a non-empty cache."""
+        """
+        Get the number of spatial patches.
+
+        Returns
+        -------
+        int
+            The number of patches.
+
+        Raises
+        ------
+        FileNotFoundError
+            If not data is cached yet.
+        """
         return len(self.get_patch_centers())
 
     def drop(self) -> None:
-        """Delete the entire cache directy. Invalidates this instance."""
+        """Delete the entire cache directy."""
         shutil.rmtree(self.path)
 
 
 class YawCacheHandle(DataHandle):
+    """Class to act as a handle for a `YawCache` instance, associating it with a
+    file and providing tools to read & write it to that file.
+
+    Parameters
+    ----------
+    tag : str
+        The tag under which this data handle can be found in the store.
+    data : any or None
+        The associated data.
+    path : str or None
+        The path to the associated file.
+    creator : str or None
+        The name of the stage that created this data handle.
+    """
+
     data: YawCache
 
     @classmethod
@@ -287,14 +454,13 @@ class YawCacheHandle(DataHandle):
     @classmethod
     def _read(cls, path: str, **kwargs) -> YawCache:
         with cls._open(path, **kwargs) as f:
-            inst_args = json.load(f)
-        return YawCache(**inst_args)
+            path = f.read()
+        return YawCache(path)
 
     @classmethod
     def _write(cls, data: YawCache, path: str, **kwargs) -> None:
         with cls._open(path, mode="w") as f:
-            inst_args = dict(path=data.path)  # can restore cache from path alone
-            json.dump(inst_args, f)
+            f.write(data.path)
 
 
 def handle_has_path(handle: DataHandle) -> bool:
@@ -311,15 +477,9 @@ class YawCacheCreate(
     ),
 ):
     """
-    Split a data and (optional) random data set into spatial patches and
-    cache them on disk.
+    TODO.
 
     @YawParameters
-
-    Returns
-    -------
-    cache: YawCacheHandle
-        Handle to the newly created cache directory.
     """
 
     inputs = [
@@ -368,16 +528,34 @@ class YawCacheCreate(
         self.add_data("cache", cache)
 
 
-def stage_helper(name: str) -> dict[str, Any]:
+def stage_helper(suffix: str) -> dict[str, Any]:
+    """
+    Create an alias mapping for all `YawCacheCreate` stage in- and outputs.
+
+    Useful when creating a new stage with `make_stage`, e.g. by setting
+    `aliases=stage_helper("suffix")`.
+
+    Parameters
+    ----------
+    name : str
+        The suffix to append to the in- and output tags, e.g. `"data_suffix"`.
+
+    Returns
+    -------
+    dict
+        Mapping from original to aliased in- and output tags.
+    """
     keys = []
     keys.extend(key for key, _ in YawCacheCreate.inputs)
     keys.extend(key for key, _ in YawCacheCreate.outputs)
-    return {key: f"{key}_{name}" for key in keys}
+    return {key: f"{key}_{suffix}" for key in keys}
 
 
 class YawCacheDrop(YawRailStage):
     """
-    Delete an existing cache.
+    TODO.
+
+    @YawParameters
     """
 
     inputs = [

--- a/src/rail/yaw_rail/correlation.py
+++ b/src/rail/yaw_rail/correlation.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 import h5py
 from yaw import Configuration, CorrFunc, autocorrelate, crosscorrelate
 
+from ceci.stage import StageParameter
 from rail.core.data import DataHandle
 from rail.yaw_rail.cache import YawCacheHandle
 from rail.yaw_rail.logging import yaw_logged
@@ -37,9 +38,15 @@ yaw_config_zbins = {
     p: create_param("binning", p)
     for p in ("zmin", "zmax", "zbin_num", "method", "zbins")
 }
-yaw_config_backend = {
-    p: create_param("backend", p) for p in ("crosspatch", "thread_num")
-}
+yaw_config_backend = {p: create_param("backend", p) for p in ("crosspatch",)}
+# Since the current implementation does not support MPI, we need to implement
+# the number of threads manually. The code uses multiprocessing and can only
+# run on a single machine.
+yaw_config_backend["thread_num"] = StageParameter(
+    int,
+    required=False,
+    msg="the number of threads to use by the multiprocessing backend (single machine, MPI not yet supported)",
+)
 
 
 class YawCorrFuncHandle(DataHandle):

--- a/src/rail/yaw_rail/correlation.py
+++ b/src/rail/yaw_rail/correlation.py
@@ -50,6 +50,21 @@ yaw_config_backend["thread_num"] = StageParameter(
 
 
 class YawCorrFuncHandle(DataHandle):
+    """Class to act as a handle for a `yaw.CorrFunc` instance, associating it
+    with a file and providing tools to read & write it to that file.
+
+    Parameters
+    ----------
+    tag : str
+        The tag under which this data handle can be found in the store.
+    data : any or None
+        The associated data.
+    path : str or None
+        The path to the associated file.
+    creator : str or None
+        The name of the stage that created this data handle.
+    """
+
     data: CorrFunc
 
     @classmethod
@@ -66,7 +81,7 @@ class YawCorrFuncHandle(DataHandle):
 
 
 class YawBaseCorrelate(YawRailStage):
-    """Base class for correlation measurement stages"""
+    """Base class for correlation measurement stages."""
 
     inputs: list[tuple[str, YawCacheHandle]]
     outputs: list[tuple[str, YawCorrFuncHandle]]
@@ -95,15 +110,9 @@ class YawAutoCorrelate(
     ),
 ):
     """
-    Measure the autocorrelation function amplitude for the give data sample.
+    TODO.
 
     @YawParameters
-
-    Returns
-    -------
-    corrfunc: YawCorrFuncHandle
-        The measured correlation function stored as pair counts per spatial
-        patch and redshift bin.
     """
 
     inputs = [
@@ -148,16 +157,9 @@ class YawCrossCorrelate(
     ),
 ):
     """
-    Measure the cross-correlation function amplitude for the give reference
-    and unknown sample.
+    TODO.
 
     @YawParameters
-
-    Returns
-    -------
-    corrfunc: YawCorrFuncHandle
-        The measured correlation function stored as pair counts per spatial
-        patch and redshift bin.
     """
 
     inputs = [

--- a/src/rail/yaw_rail/correlation.py
+++ b/src/rail/yaw_rail/correlation.py
@@ -50,7 +50,8 @@ yaw_config_backend["thread_num"] = StageParameter(
 
 
 class YawCorrFuncHandle(DataHandle):
-    """Class to act as a handle for a `yaw.CorrFunc` instance, associating it
+    """
+    Class to act as a handle for a `yaw.CorrFunc` instance, associating it
     with a file and providing tools to read & write it to that file.
 
     Parameters
@@ -96,10 +97,6 @@ class YawBaseCorrelate(YawRailStage):
     def correlate(self, *inputs: YawCache) -> YawCorrFuncHandle:
         pass  # pragma: no cover
 
-    @abstractmethod
-    def run(self) -> None:
-        pass  # pragma: no cover
-
 
 class YawAutoCorrelate(
     YawBaseCorrelate,
@@ -110,9 +107,12 @@ class YawAutoCorrelate(
     ),
 ):
     """
-    TODO.
+    Wrapper stage for `yaw.autocorrelate` to compute a sample's angular
+    autocorrelation amplitude.
 
-    @YawParameters
+    Generally used for the reference sample to compute an estimate for its
+    galaxy sample as a function of redshift. Data is provided as a single cache
+    directory that must have redshifts and randoms with redshift attached.
     """
 
     inputs = [
@@ -123,6 +123,20 @@ class YawAutoCorrelate(
     ]
 
     def correlate(self, sample: YawCache) -> YawCorrFuncHandle:  # pylint: disable=W0221
+        """
+        Measure the angular autocorrelation amplitude in bins of redshift.
+
+        Parameters
+        ----------
+        sample : YawCache
+            Input cache which must have randoms attached and redshifts for both
+            data set and randoms.
+
+        Returns
+        -------
+        YawCorrFuncHandle
+            A handle for the `yaw.CorrFunc` instance that holds the pair counts.
+        """
         self.set_data("sample", sample)
 
         self.run()
@@ -157,9 +171,13 @@ class YawCrossCorrelate(
     ),
 ):
     """
-    TODO.
+    Wrapper stage for `yaw.crosscorrelate` to compute the angular cross-
+    correlation amplitude between the reference and the unknown sample.
 
-    @YawParameters
+    Generally used for the reference sample to compute an estimate for its
+    galaxy sample as a function of redshift. Data sets are provided as cache
+    directories. The reference sample must have redshifts and at least one
+    cache must have randoms attached.
     """
 
     inputs = [
@@ -173,6 +191,23 @@ class YawCrossCorrelate(
     def correlate(  # pylint: disable=W0221
         self, reference: YawCache, unknown: YawCache
     ) -> YawCorrFuncHandle:
+        """
+        Measure the angular cross-correlation amplitude in bins of redshift.
+
+        Parameters
+        ----------
+        reference : YawCache
+            Cache for the reference data, must have redshifts. If no randoms are
+            attached, the unknown data cache must provide them.
+        unknown : YawCache
+            Cache for the unknown data. If no randoms are attached, the
+            reference data cache must provide them.
+
+        Returns
+        -------
+        YawCorrFuncHandle
+            A handle for the `yaw.CorrFunc` instance that holds the pair counts.
+        """
         self.set_data("reference", reference)
         self.set_data("unknown", unknown)
 

--- a/src/rail/yaw_rail/logging.py
+++ b/src/rail/yaw_rail/logging.py
@@ -26,6 +26,9 @@ config_verbose = StageParameter(
 
 
 class OnlyYawFilter(logging.Filter):
+    """A logging filter that rejects all messages not emitted by
+    *yet_another_wizz*."""
+
     def filter(self, record):
         record.exc_info = None
         record.exc_text = None
@@ -33,6 +36,8 @@ class OnlyYawFilter(logging.Filter):
 
 
 def init_logger(level: str = "info") -> logging.Logger:
+    """Init a logger that writes *yet_another_wizz* messages to stderr in a
+    custom format."""
     level = getattr(logging, level.upper())
     formatter = logging.Formatter("%(levelname)s:%(name)s:%(message)s")
 
@@ -47,6 +52,16 @@ def init_logger(level: str = "info") -> logging.Logger:
 
 @contextmanager
 def yaw_logged(level: str = "debug"):
+    """
+    Context manager that creates a temporary logger that redirects messages
+    emitted by *yet_another_wizz* to stderr.
+
+    Parameters
+    ----------
+    level : str
+        Controlls how verbose messages are, options are `"critical"`, `"error"`,
+        `"warning"`, `"info"`, or `"debug"`.
+    """
     logger = init_logger(level=level)
     try:
         yield logger

--- a/src/rail/yaw_rail/stage.py
+++ b/src/rail/yaw_rail/stage.py
@@ -1,9 +1,9 @@
 """
-This file implements a utility functions that automatically create
+This file implements utility functions that automatically create
 `ceci.config.StageParameter` instances from their corresponding parameter in
 *yet_another_wizz* by hooking into its integrated help system. Additionally,
-it provides a decorator for RAIL stages that automatically populates the
-stage configuration and building class doc-string.
+it provides a custom base class for `RailStages` that automates some of the
+stage properties and configuration definition.
 """
 
 from __future__ import annotations
@@ -30,7 +30,7 @@ __all__ = [
 
 
 def get_yaw_config_meta(config_cls: Any, parname: str) -> dict[str, Any]:
-    """Convert parameter metadata, embedded into the yet_another_wizz
+    """Convert parameter metadata, embedded into the *yet_another_wizz*
     configuration dataclasses, to a python dictionary."""
     for field in fields(config_cls):
         if field.name == parname:
@@ -44,10 +44,28 @@ def create_param(
     category: Literal["backend", "binning", "scales", "resampling"],
     parname: str,
 ) -> StageParameter:
-    """Hook into the yet_another_wizz parameter defaults and help system to
-    construct a StageParameter."""
+    """
+    Hook into the help system and defaults to construct a `StageParameter` from
+    a *yet_another_wizz* configuration parameter.
 
-    config_cls_name = category.capitalize() + "Config"
+    Parameters
+    ----------
+    category : str
+        Prefix of one of the *yet_another_wizz* configuration classes that
+        defines the parameter of interest, e.g. `"scales"` for
+        `yaw.config.ScalesConfig`.
+    parname : str
+        The name of the parameter of interest, e.g. `"rmin"` for
+        `yaw.config.ScalesConfig.rmin`.
+
+    Returns
+    -------
+    StageParameter
+        Parameter metadata including `dtype`, `default`, `required` and `msg`
+        values set.
+    """
+
+    config_cls_name = category.lower().capitalize() + "Config"
     metadata = get_yaw_config_meta(
         config_cls=getattr(config, config_cls_name),
         parname=parname,
@@ -65,7 +83,42 @@ def create_param(
 
 
 class YawRailStage(ABC, RailStage):
+    """
+    Base class for any `RailStage` used in this wrapper package.
+
+    It introduces a few quality-of-life improvements compared to the base
+    `RailStage` when creating a sub-class. These include:
+
+    - setting the `name` attribute automatically to the class name,
+    - copying the default `RailStage.config_options`,
+    - providing an interface to directly register a dictionary of algorithm-
+      specific configuration parameters.
+    - automatically adding the `"verbose"` parameter to the stage, which
+      controlls the log-level filtering for the *yet_another_wizz* logger.
+
+    The names of all algorithm-specific parameters are tracked in the special
+    attribute `algo_parameters`. There is a special method to get a dictionary
+    of just those parameters.
+
+    Additionally, there are methods to set and retrieve (optional) stage inputs
+    that do not raise exceptions if the handle has not been assigned.
+
+    Examples
+    --------
+    Create a new stage with one algorithm specific parameter called `"param"`.
+    The resulting subclass will have the standard `RailStage` parameters and an
+    additional parameter `"verbose"`.
+
+    >>> class MyStage(
+    ...     YawRailStage,
+    ...     config_items=dict(
+    ...         param=StageParameter(dtype=int)
+    ...     ),
+    ... ):
+    """
+
     algo_parameters: set[str]
+    """Lists the names of all algorithm-specific parameters."""
 
     def __init_subclass__(cls, config_items: dict[str, StageParameter] | None = None):
         cls.name = cls.__name__
@@ -98,6 +151,22 @@ class YawRailStage(ABC, RailStage):
     def get_algo_config_dict(
         self, exclude: Container[str] | None = None
     ) -> dict[str, Any]:
+        """
+        Return the algorithm-specific configuration.
+
+        Same as `get_config_dict`, but only returns those parameters that are
+        listed in `algo_parameters`.
+
+        Parameters
+        ----------
+        exclude : Container of str, optional
+            Listing of parameters not to include in the output.
+
+        Returns
+        -------
+        dict
+            Dictionary containing pairs of parameter names and (default) values.
+        """
         if exclude is None:
             exclude = []
         return {
@@ -107,17 +176,59 @@ class YawRailStage(ABC, RailStage):
         }
 
     def get_optional_handle(self, tag: str, **kwarg) -> DataHandle | None:
+        """
+        Access a handle without raising a `KeyError` if it is not set.
+
+        Parameters
+        ----------
+        tag : str
+            The requested tag.
+        **kwargs : dict, optional
+            Parameters passed on to `get_handle`.
+
+        Returns
+        -------
+        DataHandle or None
+            The handle or nothing if not set.
+        """
         try:
             return self.get_handle(tag, allow_missing=False, **kwarg)
         except KeyError:
             return None
 
     def get_optional_data(self, tag: str, **kwarg) -> Any | None:
+        """
+        Access a handle's data without raising a `get_data` if it is not set.
+
+        Parameters
+        ----------
+        tag : str
+            The requested tag.
+        **kwargs : dict, optional
+            Parameters passed on to `get_data`.
+
+        Returns
+        -------
+        Any or None
+            The handle's data or nothing if not set.
+        """
         try:
             return self.get_data(tag, allow_missing=False, **kwarg)
         except KeyError:
             return None
 
     def set_optional_data(self, tag: str, value: Any | None, **kwarg) -> None:
+        """
+        Set a handle's data if the value is not None.
+
+        Parameters
+        ----------
+        tag : str
+            The requested tag.
+        value : Any or None
+            The data to assing to the handle unless `None` is provided.
+        **kwargs : dict, optional
+            Parameters passed on to `set_data`.
+        """
         if value is not None:
             self.set_data(tag, value, **kwarg)

--- a/src/rail/yaw_rail/stage.py
+++ b/src/rail/yaw_rail/stage.py
@@ -92,7 +92,7 @@ class YawRailStage(ABC, RailStage):
     - setting the `name` attribute automatically to the class name,
     - copying the default `RailStage.config_options`,
     - providing an interface to directly register a dictionary of algorithm-
-      specific configuration parameters.
+      specific configuration parameters, and
     - automatically adding the `"verbose"` parameter to the stage, which
       controlls the log-level filtering for the *yet_another_wizz* logger.
 

--- a/src/rail/yaw_rail/stage.py
+++ b/src/rail/yaw_rail/stage.py
@@ -77,9 +77,9 @@ class YawRailStage(ABC, RailStage):
             config_items = {}
         else:
             config_items = copy(config_items)
-        cls.config_options.update(config_items)
         cls.algo_parameters = set(config_items.keys())
 
+        cls.config_options.update(config_items)
         cls.config_options["verbose"] = config_verbose  # used for yaw logger
 
         param_str = "Parameters\n    ----------\n"
@@ -87,6 +87,7 @@ class YawRailStage(ABC, RailStage):
         for name, param in config_items.items():
             msg = param._help  # pylint: disable=W0212; PR filed in ceci
             param_str += param_template.format(name, param.dtype.__name__, msg)
+
         param_str += param_template.format(
             "verbose",
             config_verbose.dtype.__name__,

--- a/src/rail/yaw_rail/summarize.py
+++ b/src/rail/yaw_rail/summarize.py
@@ -52,6 +52,8 @@ yaw_config_resampling = {
 
 
 def clip_negative_values(nz: RedshiftData) -> RedshiftData:
+    """Replace all non-finite and negative values in a `yaw.RedshiftData`
+    instance with zeros."""
     data = np.nan_to_num(nz.data, nan=0.0, posinf=0.0, neginf=0.0)
     samples = np.nan_to_num(nz.samples, nan=0.0, posinf=0.0, neginf=0.0)
 
@@ -65,6 +67,8 @@ def clip_negative_values(nz: RedshiftData) -> RedshiftData:
 
 
 def redshift_data_to_qp(nz: RedshiftData) -> qp.Ensemble:
+    """Convert a `yaw.RedshiftData` instance to a `qp.Ensemble` by clipping
+    negative values and normalising the spatial samples to PDFs."""
     nz_clipped = clip_negative_values(nz)
     nz_mids = nz_clipped.mids
 
@@ -76,6 +80,21 @@ def redshift_data_to_qp(nz: RedshiftData) -> qp.Ensemble:
 
 
 class YawRedshiftDataHandle(DataHandle):
+    """Class to act as a handle for a `yaw.RedshiftData` instance, associating
+    it with a file and providing tools to read & write it to that file.
+
+    Parameters
+    ----------
+    tag : str
+        The tag under which this data handle can be found in the store.
+    data : any or None
+        The associated data.
+    path : str or None
+        The path to the associated file.
+    creator : str or None
+        The name of the stage that created this data handle.
+    """
+
     data: RedshiftData
 
     @classmethod
@@ -103,17 +122,9 @@ class YawSummarize(
     ),
 ):
     """
-    Convert the clustering redshift estimate to an QP ensemble by clipping
-    negative values and substituting non-finite values.
+    TODO.
 
     @YawParameters
-
-    Returns
-    -------
-    output: QPHandle
-        The final QP ensemble.
-    yaw_cc: YawRedshiftDataHandle
-        A yet_another_wizz RedshiftData container containing all output data.
     """
 
     inputs = [

--- a/src/rail/yaw_rail/summarize.py
+++ b/src/rail/yaw_rail/summarize.py
@@ -80,7 +80,8 @@ def redshift_data_to_qp(nz: RedshiftData) -> qp.Ensemble:
 
 
 class YawRedshiftDataHandle(DataHandle):
-    """Class to act as a handle for a `yaw.RedshiftData` instance, associating
+    """
+    Class to act as a handle for a `yaw.RedshiftData` instance, associating
     it with a file and providing tools to read & write it to that file.
 
     Parameters
@@ -122,9 +123,17 @@ class YawSummarize(
     ),
 ):
     """
-    TODO.
+    A simple summarizer that computes a clustering redshift estimate from the
+    measured correlation amplitudes.
 
-    @YawParameters
+    Evaluates the cross-correlation pair counts with the provided estimator.
+    Additionally corrects for galaxy sample bias if autocorrelation measurements
+    are given.
+
+    .. warning::
+    This summarizer simply replaces all non-finite and negative values in the
+    clustering redshift estimate to produce PDFs. This may have significant
+    impacts on the recovered mean redshift.
     """
 
     inputs = [
@@ -147,7 +156,32 @@ class YawSummarize(
         cross_corr: CorrFunc,
         ref_corr: CorrFunc | None = None,
         unk_corr: CorrFunc | None = None,
-    ) -> dict:
+    ) -> dict[str, DataHandle]:
+        """
+        Compute a clustring redshift estimate and convert it to a PDF.
+
+        Parameters
+        ----------
+        cross_corr : CorrFunc
+            Pair counts from the cross-correlation measurement, basis for the
+            clustering redshift estimate.
+        ref_corr : CorrFunc, optional
+            Pair counts from the reference sample autocorrelation measurement,
+            used to correct for the reference sample galaxy bias.
+        unk_corr : CorrFunc, optional
+            Pair counts from the unknown sample autocorrelation measurement,
+            used to correct for the reference sample galaxy bias. Typically only
+            availble when using simulated data sets.
+
+        Returns
+        -------
+        dict
+            Dictionary with keys `"output"` and `"yaw_cc"`:
+            1. `QPHandle` containing PDFs of the estimated spatial samples.
+            2. `YawRedshiftDataHandle` wrapping the direct output of
+               *yet_another_wizz*; the clustering redshift estimate, spatial
+               samples thereof, and its covariance matrix.
+        """
         self.set_data("cross_corr", cross_corr)
         self.set_optional_data("ref_corr", ref_corr)
         self.set_optional_data("unk_corr", unk_corr)

--- a/src/rail/yaw_rail/utils.py
+++ b/src/rail/yaw_rail/utils.py
@@ -1,3 +1,7 @@
+"""
+This module implements some simple utility functions.
+"""
+
 from __future__ import annotations
 
 from functools import lru_cache
@@ -15,4 +19,13 @@ __all__ = [
 
 @lru_cache
 def get_dc2_test_data() -> DataFrame:
+    """
+    Download a small dataset with positions and redshifts, derived from DC2.
+
+    Returns
+    -------
+    DataFrame
+        Table containing right ascension (`ra`), declination (`dec`) and
+        redshift (`z`).
+    """
     return read_parquet("https://portal.nersc.gov/cfs/lsst/PZ/test_dc2_rail_yaw.pqt")

--- a/tests/yaw_rail/test_stage.py
+++ b/tests/yaw_rail/test_stage.py
@@ -9,7 +9,10 @@ from rail.core.stage import RailStage
 from rail.yaw_rail import stage
 
 
-class TestStage(stage.YawRailStage, config_items=dict(test=StageParameter(dtype=int))):
+class StageTester(
+    stage.YawRailStage,
+    config_items=dict(test=StageParameter(dtype=int)),
+):
     """@YawParameters"""
 
     inputs = [("input", TableHandle)]
@@ -21,9 +24,9 @@ class StageMakerAliased:
     count = 0
 
     @classmethod
-    def make_stage(cls) -> TestStage:
+    def make_stage(cls) -> StageTester:
         cls.count += 1
-        return TestStage.make_stage(
+        return StageTester.make_stage(
             test=0, name=f"stage{cls.count}", aliases=dict(input=f"input_{cls.count}")
         )
 
@@ -35,12 +38,12 @@ def make_test_handle() -> TableHandle:
 
 class TestYawRailStage:
     def test_init_subclass(self):
-        assert TestStage.name == TestStage.__name__
-        assert set(TestStage.config_options) == (
-            set(RailStage.config_options) | TestStage.algo_parameters | {"verbose"}
+        assert StageTester.name == StageTester.__name__
+        assert set(StageTester.config_options) == (
+            set(RailStage.config_options) | StageTester.algo_parameters | {"verbose"}
         )
-        assert "test" in TestStage.__doc__
-        assert "verbose" in TestStage.__doc__
+        assert "test" in StageTester.__doc__
+        assert "verbose" in StageTester.__doc__
 
     def test_get_algo_config_dict(self):
         test_stage = StageMakerAliased.make_stage()

--- a/tests/yaw_rail/test_stage.py
+++ b/tests/yaw_rail/test_stage.py
@@ -13,10 +13,13 @@ class StageTester(
     stage.YawRailStage,
     config_items=dict(test=StageParameter(dtype=int)),
 ):
-    """@YawParameters"""
+    """__doc__"""
 
     inputs = [("input", TableHandle)]
     outputs = [("output", TableHandle)]
+
+    def run(self):
+        pass
 
 
 class StageMakerAliased:
@@ -42,6 +45,8 @@ class TestYawRailStage:
         assert set(StageTester.config_options) == (
             set(RailStage.config_options) | StageTester.algo_parameters | {"verbose"}
         )
+        assert StageTester.__doc__.startswith("__doc__")
+        # NOTE: doc-strings not updated if StageTester has any abstract methods
         assert "test" in StageTester.__doc__
         assert "verbose" in StageTester.__doc__
 


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

- Added all missing doc strings to comply with code style.
- Fixed the subclassing of `YawRailStage` and its interference to the parent class `ceci.PipelineStage`.
- Added an option to overwrite existing caches and added additional safety checks that prohibit accidental data loss with the `YawCache.drop` method.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
