### PR TITLE
fixed the PyPI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![yet_another_wizz](https://raw.githubusercontent.com/jlvdb/yet_another_wizz/main/docs/source/_static/logo-dark.png)
 
-[![PyPI](https://img.shields.io/pypi/v/yaw_rail?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/yaw_rail/)
+[![PyPI](https://img.shields.io/pypi/v/pz-rail-yaw?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/pz-rail-yaw/)
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/LSSTDESC/rail_yaw/smoke-test.yml)](https://github.com/LSSTDESC/rail_yaw/actions/workflows/smoke-test.yml)
 [![codecov](https://codecov.io/gh/LSSTDESC/rail_yaw/graph/badge.svg?token=BsmWz2v0qL)](https://codecov.io/gh/LSSTDESC/rail_yaw)
 [![Template](https://img.shields.io/badge/Template-LINCC%20Frameworks%20Python%20Project%20Template-brightgreen)](https://lincc-ppt.readthedocs.io/en/latest/)


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

- Fixed the PyPI badge URL.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
