### PR TITLE
Fixing the example pipeline generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ dynamic = ["version"]
 dependencies = [
     "numpy",
     "h5py",
-    "ceci<2.0",  # there is a compatibility issue between RAIL and ceci v2.0
-    "pz-rail-base",
+    "pz_rail_base>=1.0.3",
     "qp-prob",
     # fix yet_another_wizz version; if there is a new release, issue a new
     # patch or minor version release, depending on the changes requred

--- a/src/rail/estimation/algos/cc_yaw.py
+++ b/src/rail/estimation/algos/cc_yaw.py
@@ -44,6 +44,7 @@ __all__ = [
     "YawAutoCorrelate",
     "YawCrossCorrelate",
     "YawSummarize",
+    "create_yaw_cache_alias",
 ]
 
 

--- a/src/rail/estimation/algos/cc_yaw.py
+++ b/src/rail/estimation/algos/cc_yaw.py
@@ -227,8 +227,8 @@ class YawAutoCorrelate(
         ("output", YawCorrFuncHandle),
     ]
 
-    def __init__(self, args, comm=None):
-        super().__init__(args, comm)
+    def __init__(self, args, **kwargs):
+        super().__init__(args, **kwargs)
         warn_thread_num_deprecation(self.get_algo_config_dict())
 
     def correlate(self, sample: YawCacheHandle | YawCache) -> YawCorrFuncHandle:
@@ -295,8 +295,8 @@ class YawCrossCorrelate(
         ("output", YawCorrFuncHandle),
     ]
 
-    def __init__(self, args, comm=None):
-        super().__init__(args, comm)
+    def __init__(self, args, **kwargs):
+        super().__init__(args, **kwargs)
         warn_thread_num_deprecation(self.get_algo_config_dict())
 
     def correlate(
@@ -388,8 +388,8 @@ class YawSummarize(
         ("output", ModelHandle),
     ]
 
-    def __init__(self, args, comm=None):
-        super().__init__(args, comm=comm)
+    def __init__(self, args, **kwargs):
+        super().__init__(args, **kwargs)
         config = {p: self.config_options[p].value for p in stage_config.yaw_resampling}
         self.yaw_config = ResamplingConfig.create(**config)
 

--- a/src/rail/pipelines/estimation/build_pipeline.py
+++ b/src/rail/pipelines/estimation/build_pipeline.py
@@ -151,4 +151,4 @@ if __name__ == "__main__":
         run_config=dict(output_dir=data_dir, log_dir=log_dir, resume=False),
         stages_config=None,
     )
-    pipe.save("yaw_pipeline.yml", site_name="local")
+    pipe.save(os.path.join(root, "yaw_pipeline.yml"), site_name="local")

--- a/src/rail/pipelines/estimation/build_pipeline.py
+++ b/src/rail/pipelines/estimation/build_pipeline.py
@@ -5,6 +5,7 @@
 #
 
 # pylint: skip-file
+import argparse
 import os
 from shutil import rmtree
 
@@ -24,16 +25,19 @@ except NameError:
     from rail.estimation.algos.cc_yaw import *
 
 
-DATA = "data"
-LOGS = "logs"
 VERBOSE = "debug"  # verbosity level of built-in logger, disable with "error"
+
+parser = argparse.ArgumentParser(
+    description="Generate test data and build the rail_yaw ceci example pipeline."
+)
+parser.add_argument("--root", default=".")
 
 # configuration for the correlation measurements
 corr_config = dict(
     rmin=100,
     rmax=1000,
-    zmin=0.0,
-    zmax=3.0,
+    zmin=0.2,
+    zmax=1.8,
     zbin_num=8,
     verbose=VERBOSE,
 )
@@ -66,7 +70,7 @@ def create_datasets(root):
 
 class YawPipeline(FixedRailPipeline):
 
-    def __init__(self):
+    def __init__(self, data_dir, log_dir):
         FixedRailPipeline.__init__(self)
 
         DS = RailStage.data_store
@@ -74,7 +78,7 @@ class YawPipeline(FixedRailPipeline):
 
         self.cache_ref = YawCacheCreate.build(
             aliases=create_yaw_cache_alias("ref"),
-            path=os.path.join(DATA, "test_ref"),
+            path=os.path.join(data_dir, "test_ref"),
             overwrite=True,
             ra_name="ra",
             dec_name="dec",
@@ -88,7 +92,7 @@ class YawPipeline(FixedRailPipeline):
                 patch_source=self.cache_ref.io.output,
             ),
             aliases=create_yaw_cache_alias("unk"),
-            path=os.path.join(DATA, "test_unk"),
+            path=os.path.join(data_dir, "test_unk"),
             overwrite=True,
             ra_name="ra",
             dec_name="dec",
@@ -120,13 +124,21 @@ class YawPipeline(FixedRailPipeline):
 
 
 if __name__ == "__main__":
-    for folder in (DATA, LOGS):
+    root = parser.parse_args().root
+    print(f"setting working directory: {root}")
+    if not os.path.exists(root):
+        os.mkdir(root)
+
+    data_dir = os.path.join(root, "data")
+    log_dir = os.path.join(root, "logs")
+    for folder in (data_dir, log_dir):
         if os.path.exists(folder):
             rmtree(folder)
         os.mkdir(folder)
-    data_path, rand_path = create_datasets(DATA)
 
-    pipe = YawPipeline()
+    data_path, rand_path = create_datasets(data_dir)
+
+    pipe = YawPipeline(data_dir, log_dir)
     pipe.initialize(
         overall_inputs=dict(
             data_ref=data_path,
@@ -136,7 +148,7 @@ if __name__ == "__main__":
             patch_source_ref="none",
             auto_corr_unk="none",
         ),
-        run_config=dict(output_dir=DATA, log_dir=LOGS, resume=False),
+        run_config=dict(output_dir=data_dir, log_dir=log_dir, resume=False),
         stages_config=None,
     )
     pipe.save("yaw_pipeline.yml", site_name="local")

--- a/src/rail/pipelines/estimation/plot_output.py
+++ b/src/rail/pipelines/estimation/plot_output.py
@@ -11,5 +11,7 @@ import os
 
 with open(os.path.join("data", "output_summarize.pkl"), "rb") as f:
     ncc = pickle.load(f)
+    ncc.to_files(os.path.join("data", "output"))
 ax = ncc.plot(zero_line=True)
+ax.set_xlabel("Redshift")
 ax.figure.savefig(os.path.join("data", "checkplot.png"))

--- a/src/rail/pipelines/estimation/run_pipeline.sh
+++ b/src/rail/pipelines/estimation/run_pipeline.sh
@@ -8,5 +8,6 @@ set -e
 
 time ceci yaw_pipeline.yml
 echo
+export MPLBACKEND=qtagg
 python3 plot_output.py
 echo "inspect outputs in $(pwd)/data"

--- a/src/rail/pipelines/estimation/run_pipeline.sh
+++ b/src/rail/pipelines/estimation/run_pipeline.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # This scripts runs the pipeline produced by build_pipeline.py and plots the
 # output which can be found in data/
@@ -7,5 +7,6 @@
 set -e
 
 time ceci yaw_pipeline.yml
-python plot_output.py
+echo
+python3 plot_output.py
 echo "inspect outputs in $(pwd)/data"

--- a/src/rail/pipelines/estimation/yaw_pipeline.yml
+++ b/src/rail/pipelines/estimation/yaw_pipeline.yml
@@ -1,14 +1,14 @@
 config: yaw_pipeline_config.yml
 inputs:
   auto_corr_unk: none
-  data_ref: data/input_data.parquet
-  data_unk: data/input_data.parquet
+  data_ref: ./data/input_data.parquet
+  data_unk: ./data/input_data.parquet
   patch_source_ref: none
-  rand_ref: data/input_rand.parquet
+  rand_ref: ./data/input_rand.parquet
   rand_unk: none
-log_dir: logs
+log_dir: ./logs
 modules: rail
-output_dir: data
+output_dir: ./data
 resume: false
 site:
   max_threads: 2

--- a/src/rail/pipelines/estimation/yaw_pipeline.yml
+++ b/src/rail/pipelines/estimation/yaw_pipeline.yml
@@ -1,36 +1,57 @@
-config: yaw_pipeline_config.yml
-inputs:
-  auto_corr_unk: none
-  data_ref: ./data/input_data.parquet
-  data_unk: ./data/input_data.parquet
-  patch_source_ref: none
-  rand_ref: ./data/input_rand.parquet
-  rand_unk: none
-log_dir: ./logs
-modules: rail
 output_dir: ./data
+log_dir: ./logs
 resume: false
+config: yaw_pipeline_config.yml
+modules: rail
+inputs:
+  data_ref: ./data/input_data.parquet
+  rand_ref: ./data/input_rand.parquet
+  data_unk: ./data/input_data.parquet
+  rand_unk: none
+  patch_source_ref: none
+  auto_corr_unk: none
+stages:
+- name: cache_ref
+  classname: YawCacheCreate
+  nprocess: 1
+  module_name: rail.estimation.algos.cc_yaw
+  aliases:
+    data: data_ref
+    rand: rand_ref
+    patch_source: patch_source_ref
+    output: output_cache_ref
+- name: cache_unk
+  classname: YawCacheCreate
+  nprocess: 1
+  module_name: rail.estimation.algos.cc_yaw
+  aliases:
+    data: data_unk
+    rand: rand_unk
+    patch_source: output_cache_ref
+    output: output_cache_unk
+- name: auto_corr
+  classname: YawAutoCorrelate
+  nprocess: 1
+  module_name: rail.estimation.algos.cc_yaw
+  aliases:
+    output: output_auto_corr
+    sample: output_cache_ref
+- name: cross_corr
+  classname: YawCrossCorrelate
+  nprocess: 1
+  module_name: rail.estimation.algos.cc_yaw
+  aliases:
+    output: output_cross_corr
+    reference: output_cache_ref
+    unknown: output_cache_unk
+- name: summarize
+  classname: YawSummarize
+  nprocess: 1
+  module_name: rail.estimation.algos.cc_yaw
+  aliases:
+    output: output_summarize
+    cross_corr: output_cross_corr
+    auto_corr_ref: output_auto_corr
 site:
   max_threads: 2
   name: local
-stages:
-- classname: YawCacheCreate
-  module_name: rail.estimation.algos.cc_yaw
-  name: cache_ref
-  nprocess: 1
-- classname: YawCacheCreate
-  module_name: rail.estimation.algos.cc_yaw
-  name: cache_unk
-  nprocess: 1
-- classname: YawAutoCorrelate
-  module_name: rail.estimation.algos.cc_yaw
-  name: auto_corr
-  nprocess: 1
-- classname: YawCrossCorrelate
-  module_name: rail.estimation.algos.cc_yaw
-  name: cross_corr
-  nprocess: 1
-- classname: YawSummarize
-  module_name: rail.estimation.algos.cc_yaw
-  name: summarize
-  nprocess: 1

--- a/src/rail/pipelines/estimation/yaw_pipeline_config.yml
+++ b/src/rail/pipelines/estimation/yaw_pipeline_config.yml
@@ -15,8 +15,8 @@ auto_corr:
   verbose: debug
   zbin_num: 8
   zbins: null
-  zmax: 3.0
-  zmin: 0.0
+  zmax: 1.8
+  zmin: 0.2
 cache_ref:
   aliases:
     data: data_ref
@@ -33,7 +33,7 @@ cache_ref:
   patch_file: null
   patch_name: null
   patch_source: None
-  path: data/test_ref
+  path: ./data/test_ref
   ra_name: ra
   rand: None
   redshift_name: z
@@ -55,7 +55,7 @@ cache_unk:
   patch_file: null
   patch_name: null
   patch_source: None
-  path: data/test_unk
+  path: ./data/test_unk
   ra_name: ra
   rand: None
   redshift_name: null
@@ -80,8 +80,8 @@ cross_corr:
   verbose: debug
   zbin_num: 8
   zbins: null
-  zmax: 3.0
-  zmin: 0.0
+  zmax: 1.8
+  zmin: 0.2
 summarize:
   aliases:
     auto_corr_ref: output_auto_corr

--- a/src/rail/pipelines/estimation/yaw_pipeline_config.yml
+++ b/src/rail/pipelines/estimation/yaw_pipeline_config.yml
@@ -1,100 +1,67 @@
-auto_corr:
-  aliases:
-    output: output_auto_corr
-    sample: output_cache_ref
-  config: null
-  method: linear
-  name: auto_corr
-  output_mode: default
-  rbin_num: 50
-  rmax: 1000.0
-  rmin: 100.0
-  rweight: null
-  sample: None
-  thread_num: null
-  verbose: debug
-  zbin_num: 8
-  zbins: null
-  zmax: 1.8
-  zmin: 0.2
 cache_ref:
-  aliases:
-    data: data_ref
-    output: output_cache_ref
-    patch_source: patch_source_ref
-    rand: rand_ref
-  config: null
-  data: None
-  dec_name: dec
-  n_patches: 5
-  name: cache_ref
   output_mode: default
-  overwrite: true
-  patch_file: null
-  patch_name: null
-  patch_source: None
   path: ./data/test_ref
-  ra_name: ra
-  rand: None
-  redshift_name: z
-  verbose: debug
-  weight_name: null
-cache_unk:
-  aliases:
-    data: data_unk
-    output: output_cache_unk
-    patch_source: output_cache_ref
-    rand: rand_unk
-  config: null
-  data: None
-  dec_name: dec
-  n_patches: null
-  name: cache_unk
-  output_mode: default
   overwrite: true
+  ra_name: ra
+  dec_name: dec
+  redshift_name: z
+  weight_name: null
   patch_file: null
   patch_name: null
-  patch_source: None
+  n_patches: 5
+  verbose: debug
+  name: cache_ref
+  config: null
+cache_unk:
+  output_mode: default
   path: ./data/test_unk
+  overwrite: true
   ra_name: ra
-  rand: None
+  dec_name: dec
   redshift_name: null
-  verbose: debug
   weight_name: null
-cross_corr:
-  aliases:
-    output: output_cross_corr
-    reference: output_cache_ref
-    unknown: output_cache_unk
-  config: null
-  method: linear
-  name: cross_corr
-  output_mode: default
-  rbin_num: 50
-  reference: None
-  rmax: 1000.0
-  rmin: 100.0
-  rweight: null
-  thread_num: null
-  unknown: None
+  patch_file: null
+  patch_name: null
+  n_patches: null
   verbose: debug
-  zbin_num: 8
-  zbins: null
-  zmax: 1.8
-  zmin: 0.2
-summarize:
-  aliases:
-    auto_corr_ref: output_auto_corr
-    cross_corr: output_cross_corr
-    output: output_summarize
-  auto_corr_ref: None
-  auto_corr_unk: None
+  name: cache_unk
   config: null
-  cross_corr: None
-  cross_est: null
-  crosspatch: true
-  name: summarize
+auto_corr:
   output_mode: default
+  rmin: 100.0
+  rmax: 1000.0
+  rweight: null
+  rbin_num: 50
+  zmin: 0.2
+  zmax: 1.8
+  zbin_num: 8
+  method: linear
+  zbins: null
+  thread_num: null
+  verbose: debug
+  name: auto_corr
+  config: null
+cross_corr:
+  output_mode: default
+  rmin: 100.0
+  rmax: 1000.0
+  rweight: null
+  rbin_num: 50
+  zmin: 0.2
+  zmax: 1.8
+  zbin_num: 8
+  method: linear
+  zbins: null
+  thread_num: null
+  verbose: debug
+  name: cross_corr
+  config: null
+summarize:
+  output_mode: default
+  cross_est: null
   ref_est: null
   unk_est: null
+  crosspatch: true
   verbose: debug
+  name: summarize
+  config: null

--- a/tests/estimation/algos/test_cc_yaw.py
+++ b/tests/estimation/algos/test_cc_yaw.py
@@ -1,133 +1,28 @@
 from __future__ import annotations
 
+import inspect
+import pickle
+import subprocess
 from pathlib import Path
 
 import numpy as np
 import numpy.testing as npt
 from pytest import mark, raises, warns
 
-from rail.estimation.algos.cc_yaw import (
-    create_yaw_cache_alias,
-    YawAutoCorrelate,
-    YawCacheCreate,
-    YawCrossCorrelate,
-    YawSummarize,
-)
+from rail.estimation.algos import cc_yaw
 
 
 def test_create_yaw_cache_alias():
     name = "test"
-    aliases = create_yaw_cache_alias(name)
+    aliases = cc_yaw.create_yaw_cache_alias(name)
     assert all(alias == f"{key}_{name}" for key, alias in aliases.items())
-
-
-def write_expect_wss(path: Path) -> Path:
-    target = path / "wss_expect.txt"
-    with open(target, "w") as f:
-        f.write(
-            """# correlation function estimate with symmetric 68% percentile confidence
-#    z_low     z_high         nz     nz_err
- 0.2002429  0.9998286  0.0115084  0.0039227
- 0.9998286  1.7994142  0.0224274  0.0130083
-"""
-        )
-    return target
-
-
-def write_expect_wsp(path: Path) -> Path:
-    target = path / "wsp_expect.txt"
-    with open(target, "w") as f:
-        f.write(
-            """# correlation function estimate with symmetric 68% percentile confidence
-#    z_low     z_high         nz     nz_err
- 0.2002429  0.9998286  0.0060440  0.0046580
- 0.9998286  1.7994142  0.0118823  0.0014990
-"""
-        )
-    return target
-
-
-def write_expect_ncc(path: Path) -> Path:
-    target = path / "ncc_expect.txt"
-    with open(target, "w") as f:
-        f.write(
-            """# n(z) estimate with symmetric 68% percentile confidence
-#    z_low     z_high         nz     nz_err
- 0.2002429  0.9998286  0.0704619  0.0454918
- 0.9998286  1.7994142  0.0992310  0.0185709
-"""
-        )
-    return target
-
-
-def assert_cols_match(path_a: Path, path_b: Path, *, ignore_cols: list[int]) -> None:
-    data_a = np.loadtxt(path_a).T
-    data_b = np.loadtxt(path_b).T
-    for i, (col_a, col_b) in enumerate(zip(data_a, data_b)):
-        if i in ignore_cols:
-            continue
-        npt.assert_array_equal(col_a, col_b)
-
-
-@mark.slow
-def test_run(tmp_path, mock_data, mock_rand, zlim) -> None:
-    cache_ref = YawCacheCreate.make_stage(
-        name="ref",
-        aliases=create_yaw_cache_alias("ref"),
-        path=f"{tmp_path}/test_ref",
-        ra_name="ra",
-        dec_name="dec",
-        redshift_name="z",
-        n_patches=3,
-    ).create(data=mock_data, rand=mock_rand)
-    assert cache_ref.data.data.exists()
-    assert cache_ref.data.rand.exists()
-
-    cache_unk = YawCacheCreate.make_stage(
-        name="unk",
-        aliases=create_yaw_cache_alias("unk"),
-        path=f"{tmp_path}/test_unk",
-        ra_name="ra",
-        dec_name="dec",
-    ).create(data=mock_data, patch_source=cache_ref)
-    assert cache_unk.data.data.exists()
-    assert not cache_unk.data.rand.exists()
-
-    corr_config = dict(
-        rmin=500,
-        rmax=1500,
-        zmin=zlim[0],
-        zmax=zlim[1],
-        zbin_num=2,
-    )
-
-    w_ss = YawAutoCorrelate.make_stage(name="auto_corr", **corr_config).correlate(
-        sample=cache_ref
-    )
-    w_ss.data.sample().to_files(tmp_path / "wss")
-    assert_cols_match(write_expect_wss(tmp_path), tmp_path / "wss.dat", ignore_cols=[3])
-
-    w_sp = YawCrossCorrelate.make_stage(name="cross_corr", **corr_config).correlate(
-        reference=cache_ref, unknown=cache_unk
-    )
-    w_sp.data.sample().to_files(tmp_path / "wsp")
-    assert w_sp.data.rr is None
-    assert_cols_match(write_expect_wsp(tmp_path), tmp_path / "wsp.dat", ignore_cols=[3])
-
-    ncc = YawSummarize.make_stage(name="summarize").summarize(
-        cross_corr=w_sp, auto_corr_ref=w_ss
-    )
-    ncc.data.to_files(tmp_path / "ncc")
-    assert_cols_match(write_expect_ncc(tmp_path), tmp_path / "ncc.dat", ignore_cols=[3])
-
-    # cache cleaned up by pytest
 
 
 @mark.slow
 def test_missing_randoms(tmp_path, mock_data, zlim) -> None:
-    cache_ref = YawCacheCreate.make_stage(
+    cache_ref = cc_yaw.YawCacheCreate.make_stage(
         name="ref_norand",
-        aliases=create_yaw_cache_alias("ref_norand"),
+        aliases=cc_yaw.create_yaw_cache_alias("ref_norand"),
         path=f"{tmp_path}/test_ref",
         ra_name="ra",
         dec_name="dec",
@@ -135,16 +30,16 @@ def test_missing_randoms(tmp_path, mock_data, zlim) -> None:
         n_patches=3,
     ).create(data=mock_data)
 
-    cache_unk = YawCacheCreate.make_stage(
+    cache_unk = cc_yaw.YawCacheCreate.make_stage(
         name="unk_norand",
-        aliases=create_yaw_cache_alias("unk_norand"),
+        aliases=cc_yaw.create_yaw_cache_alias("unk_norand"),
         path=f"{tmp_path}/test_unk",
         ra_name="ra",
         dec_name="dec",
     ).create(data=mock_data, patch_source=cache_ref)
 
     with raises(ValueError, match=".*no randoms.*"):
-        YawCrossCorrelate.make_stage(
+        cc_yaw.YawCrossCorrelate.make_stage(
             name="cross_corr_norand",
             rmin=500,
             rmax=1500,
@@ -156,9 +51,9 @@ def test_missing_randoms(tmp_path, mock_data, zlim) -> None:
 
 @mark.slow
 def test_cache_args(tmp_path, mock_data, mock_rand) -> None:
-    cache_ref = YawCacheCreate.make_stage(
+    cache_ref = cc_yaw.YawCacheCreate.make_stage(
         name="ref_n_patch",
-        aliases=create_yaw_cache_alias("ref_n_patch"),
+        aliases=cc_yaw.create_yaw_cache_alias("ref_n_patch"),
         path=f"{tmp_path}/test_ref",
         ra_name="ra",
         dec_name="dec",
@@ -172,9 +67,9 @@ def test_cache_args(tmp_path, mock_data, mock_rand) -> None:
         cache_ref.data.get_patch_centers().values,
     )
 
-    cache = YawCacheCreate.make_stage(
+    cache = cc_yaw.YawCacheCreate.make_stage(
         name="ref_override",
-        aliases=create_yaw_cache_alias("ref_override"),
+        aliases=cc_yaw.create_yaw_cache_alias("ref_override"),
         path=f"{tmp_path}/test_override",
         ra_name="ra",
         dec_name="dec",
@@ -183,9 +78,9 @@ def test_cache_args(tmp_path, mock_data, mock_rand) -> None:
     ).create(data=mock_data, rand=mock_rand, patch_source=cache_ref)
     assert cache.data.n_patches() == cache_ref.data.n_patches()
 
-    cache = YawCacheCreate.make_stage(
+    cache = cc_yaw.YawCacheCreate.make_stage(
         name="ref_file",
-        aliases=create_yaw_cache_alias("ref_file"),
+        aliases=cc_yaw.create_yaw_cache_alias("ref_file"),
         path=f"{tmp_path}/test_file",
         ra_name="ra",
         dec_name="dec",
@@ -202,9 +97,9 @@ def test_cache_args(tmp_path, mock_data, mock_rand) -> None:
     )
 
     with raises(ValueError, match=".*patch.*"):
-        YawCacheCreate.make_stage(
+        cc_yaw.YawCacheCreate.make_stage(
             name="ref_no_method",
-            aliases=create_yaw_cache_alias("ref_no_method"),
+            aliases=cc_yaw.create_yaw_cache_alias("ref_no_method"),
             path=f"{tmp_path}/test_no_method",
             ra_name="ra",
             dec_name="dec",
@@ -214,7 +109,7 @@ def test_cache_args(tmp_path, mock_data, mock_rand) -> None:
 
 def test_warn_thread_num_deprecation():
     with warns(FutureWarning, match=".*thread_num.*"):
-        YawCrossCorrelate.make_stage(
+        cc_yaw.YawCrossCorrelate.make_stage(
             name="cross_corr_thread_num",
             rmin=500,
             rmax=1500,
@@ -223,3 +118,55 @@ def test_warn_thread_num_deprecation():
             zbin_num=2,
             thread_num=2,
         )
+
+
+def write_expect_ncc(path: Path) -> Path:
+    target = path / "ncc_expect.txt"
+    with open(target, "w") as f:
+        f.write(
+            """# n(z) estimate with symmetric 68% percentile confidence
+#    z_low     z_high         nz     nz_err
+ 0.2000000  0.4000000  0.1160194  0.0957173
+ 0.4000000  0.6000000  0.0898476  0.0616907
+ 0.6000000  0.8000000  0.1367271  0.0815823
+ 0.8000000  1.0000000  0.2435591  0.0549643
+ 1.0000000  1.2000000  0.1789916  0.0656216
+ 1.2000000  1.4000000  0.1954614  0.0690626
+ 1.4000000  1.6000000  0.1802148  0.0765422
+ 1.6000000  1.8000000  0.1872289  0.0729730
+"""
+        )
+    return target
+
+
+@mark.slow
+def test_ceci_pipeline(tmp_path) -> None:
+    from rail.pipelines.estimation import (  # pylint: disable=C0415
+        build_pipeline as pipeline_build_scipt,
+    )
+
+    # build and run the pipeline
+    DEBUG_LOG_PATH = "/dev/null"  # change to some non-temporary location
+    build_script = inspect.getfile(pipeline_build_scipt)
+    with open(DEBUG_LOG_PATH, "w") as f:
+        subprocess.check_call(
+            ["python3", str(build_script), "--root", str(tmp_path)], stdout=f, stderr=f
+        )
+        subprocess.check_call(
+            ["ceci", str(tmp_path / "yaw_pipeline.yml")], stdout=f, stderr=f
+        )
+
+    # convert output to YAW standard YAW text files
+    with open(tmp_path / "data" / "output_summarize.pkl", "rb") as f:
+        ncc = pickle.load(f)
+        output_prefix = str(tmp_path / "output")
+        ncc.to_files(output_prefix)
+
+    # check results, ingore error column since patch centers are random
+    expect_path = write_expect_ncc(tmp_path)
+    expect_data = np.loadtxt(expect_path).T
+    output_data = np.loadtxt(f"{output_prefix}.dat").T
+    for i, (col_a, col_b) in enumerate(zip(expect_data, output_data)):
+        if i == 3:
+            break
+        npt.assert_array_equal(col_a, col_b)

--- a/tests/estimation/algos/test_cc_yaw.py
+++ b/tests/estimation/algos/test_cc_yaw.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import inspect
 import pickle
-import subprocess
 from pathlib import Path
+from subprocess import check_call
 
 import numpy as np
 import numpy.testing as npt
@@ -149,12 +149,9 @@ def test_ceci_pipeline(tmp_path) -> None:
     DEBUG_LOG_PATH = "/dev/null"  # change to some non-temporary location
     build_script = inspect.getfile(pipeline_build_scipt)
     with open(DEBUG_LOG_PATH, "w") as f:
-        subprocess.check_call(
-            ["python3", str(build_script), "--root", str(tmp_path)], stdout=f, stderr=f
-        )
-        subprocess.check_call(
-            ["ceci", str(tmp_path / "yaw_pipeline.yml")], stdout=f, stderr=f
-        )
+        redirect = dict(stdout=f, stderr=f)
+        check_call(["python3", str(build_script), "--root", str(tmp_path)], **redirect)
+        check_call(["ceci", str(tmp_path / "yaw_pipeline.yml")], **redirect)
 
     # convert output to YAW standard YAW text files
     with open(tmp_path / "data" / "output_summarize.pkl", "rb") as f:


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
The example pipeline could not be generated because `cc_yaw.create_yaw_cache_alias` was not automatically imported through `__all__` (#20).

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
