### PR TITLE
removed numpy>=2.0 requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "numpy>=2.0",
+    "numpy",
     "h5py",
     "pz-rail-base>=1.0.3",
     "yet_another_wizz>=3.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dynamic = ["version"]
 dependencies = [
     "numpy",
     "h5py",
+    "pandas",
     "pz-rail-base>=1.0.3",
     "yet_another_wizz>=3.1.0",
 ]


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

Removed the unnecessary version requirement for numpy version 2.x, which causes compatibility issues with some other ``rail`` dependencies.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
