### PR TITLE
Eac/docs

### DIFF
--- a/src/rail/estimation/algos/cc_yaw.py
+++ b/src/rail/estimation/algos/cc_yaw.py
@@ -111,11 +111,12 @@ class YawCacheCreate(
     The cache can be constructed from input files or tabular data in memory.
     Column names for sky coordinates are required, redshifts and per-object
     weights are optional. One out of three patch create methods must be
-    specified:
-    1. Splitting the data into predefined patches (from ASCII file or an
+    specified:    
+
+    #. Splitting the data into predefined patches (from ASCII file or an
        existing cache instance, linked as optional stage input).
-    2. Splitting the data based on a column with patch indices.
-    3. Generating approximately equal size patches using k-means clustering of
+    #. Splitting the data based on a column with patch indices.
+    #. Generating approximately equal size patches using k-means clustering of
        objects positions (preferably randoms if provided).
 
     **Note:** The cache directory must be deleted manually when it is no longer

--- a/src/rail/pipelines/estimation/plot_output.py
+++ b/src/rail/pipelines/estimation/plot_output.py
@@ -8,9 +8,12 @@
 import pickle
 import os
 
-with open(os.path.join("data", "output_summarize.pkl"), "rb") as f:
-    ncc = pickle.load(f)
-    ncc.to_files(os.path.join("data", "output"))
-ax = ncc.plot(indicate_zero=True)
-ax.set_xlabel("Redshift")
-ax.figure.savefig(os.path.join("data", "checkplot.png"))
+
+if __name__ == '__main__':
+
+    with open(os.path.join("data", "output_summarize.pkl"), "rb") as f:
+        ncc = pickle.load(f)
+        ncc.to_files(os.path.join("data", "output"))
+    ax = ncc.plot(indicate_zero=True)
+    ax.set_xlabel("Redshift")
+    ax.figure.savefig(os.path.join("data", "checkplot.png"))


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

I protected plot_outputs.py inside a `if __name__ == "__main__"` block so that it doesn't get run automatically by sphinx when it is making the docs.

I also reformatted one docstring to work with sphinx

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
